### PR TITLE
Update `anchored-position.ts` to support handling elements outside of `document.body` in `getClippingRect`

### DIFF
--- a/src/anchored-position.ts
+++ b/src/anchored-position.ts
@@ -206,7 +206,7 @@ function isOnTopLayer(element: Element) {
 function getClippingRect(element: Element): BoxPosition {
   let parentNode: typeof element.parentNode = element
   while (parentNode !== null) {
-    if (parentNode === document.body) {
+    if (!(parentNode instanceof Element)) {
       break
     }
     const parentNodeStyle = getComputedStyle(parentNode as Element)


### PR DESCRIPTION
Hi, thank you for implementing this great project and I've been enjoying using it in my project so far! This time I hope I could contribute back to the project.

My project has encountered such problem https://github.com/EnixCoda/Gitako/issues/294

Minimal demo to reproduce the issue: https://codesandbox.io/s/primer-react-anchor-error-fvxcsf?file=/src/App.tsx

The key point is that the anchor element is outside of `document.body`. `getClippingRect` does not expect the element to be not existing and throws error when not found.
